### PR TITLE
Change positional parameters.

### DIFF
--- a/bin/helmw
+++ b/bin/helmw
@@ -50,4 +50,4 @@ if [ ${__silent} -eq 0 ]; then
   case "$yn" in [yY]*) ;; *) echo -e "\nCancel :P\n" ; exit ;; esac
 fi
 
-exec helm --kube-context ${__kube_context} $@
+exec helm --kube-context ${__kube_context} "$@"

--- a/bin/istioctlw
+++ b/bin/istioctlw
@@ -50,4 +50,4 @@ if [ ${__silent} -eq 0 ]; then
   case "$yn" in [yY]*) ;; *) echo -e "\nCancel :P\n" ; exit ;; esac
 fi
 
-exec istioctl --context ${__kube_context} $@
+exec istioctl --context ${__kube_context} "$@"

--- a/bin/kubew
+++ b/bin/kubew
@@ -66,4 +66,4 @@ if [ ${__silent} -eq 0 ]; then
   read -p "ok? (y/N): " yn
   case "$yn" in [yY]*) ;; *) echo -e "\nCancel :P\n" ; exit ;; esac
 fi
-exec kubectl --kubeconfig ${__kube_config} --cluster ${__kube_cluster} --context ${__kube_context} $@
+exec kubectl --kubeconfig ${__kube_config} --cluster ${__kube_cluster} --context ${__kube_context} "$@"

--- a/bin/microk8sw
+++ b/bin/microk8sw
@@ -38,5 +38,4 @@ if [ ${__silent} -eq 0 ]; then
   read -p "ok? (y/N): " yn
   case "$yn" in [yY]*) ;; *) echo -e "\nCancel :P\n" ; exit ;; esac
 fi
-exec microk8s $@
-
+exec microk8s "$@"


### PR DESCRIPTION
コマンドのラッパーとして使用する場合、`$@` だと位置や要素数が変わってしまいコマンドがエラーになってしまう場合があったため、位置や要素をそのまま使用できる `"$@"` に変更しました。